### PR TITLE
fix(mcp): redirect console.log to stderr to prevent stdio transport corruption

### DIFF
--- a/packages/mcp/src/bin/awcp-mcp.ts
+++ b/packages/mcp/src/bin/awcp-mcp.ts
@@ -6,6 +6,13 @@
  * Automatically starts the Delegator Daemon if not already running.
  */
 
+// TODO: Replace with Logger injection in @awcp/sdk for structured, configurable logging
+// MCP uses stdio for JSON-RPC — any console.log (stdout) corrupts the protocol stream.
+// Redirect all console output to stderr before importing anything that might log.
+console.log = console.error;
+console.info = console.error;
+console.warn = console.error;
+
 import { createAwcpMcpServer } from '../server.js';
 import { ensureDaemonRunning, type AutoDaemonOptions } from '../auto-daemon.js';
 import { discoverPeers, type PeersContext } from '../peer-discovery.js';


### PR DESCRIPTION
## Summary

- Redirect `console.log`/`console.info`/`console.warn` to `console.error` (stderr) at the MCP entry point, before any SDK/transport code is imported
- Prevents diagnostic logging from corrupting the JSON-RPC protocol stream when MCP runs over stdio transport

## Problem

The delegator daemon and SDK (`@awcp/sdk`, `@awcp/transport-sshfs`) use `console.log` for diagnostic messages (~18 call sites). When embedded inside the MCP server process via `startDelegatorDaemon()`, these write to stdout, which is reserved for JSON-RPC messages in stdio transport. This causes:

- `Transport error for "awcp"` in Cline
- `No connection found for server` errors
- Complete MCP tool failure

## Approach

Follow the same pattern as [vscode-languageserver-node's `patchConsole()`](https://github.com/microsoft/vscode-languageserver-node/blob/main/server/src/node/main.ts) which redirects all console output when running in stdio mode. The patch is applied at the top of `awcp-mcp.ts` before any imports.

This is the minimal fix. A `TODO` comment marks the future direction: Logger injection in `@awcp/sdk` for structured, configurable logging (following the pattern used by AWS SDK v3, OpenAI SDK, etc.).

## Testing

- Verified MCP package builds successfully
- The fix ensures all output goes to stderr, which MCP spec explicitly allows: _"The server MAY write UTF-8 strings to stderr for logging purposes"_