### PR TITLE
Ps dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ id_rsa*
 id_ed25519*
 
 # Private documents
+develop_docs/
 ref/
 references/
 

--- a/packages/core/src/state-machine/assignment.ts
+++ b/packages/core/src/state-machine/assignment.ts
@@ -4,7 +4,8 @@ import type { AssignmentState, Assignment } from '../types/messages.js';
 
 const ASSIGNMENT_TRANSITIONS: Record<AssignmentState, AssignmentState[]> = {
   pending: ['active', 'error'],
-  active: ['completed', 'error'],
+  active: ['idle', 'completed', 'error'],
+  idle: ['active', 'completed', 'error'],
   completed: [],
   error: [],
 };
@@ -25,6 +26,9 @@ export function isValidAssignmentTransition(
 export type AssignmentEvent =
   | { type: 'RECEIVE_START' }
   | { type: 'TASK_COMPLETE' }
+  | { type: 'ROUND_COMPLETE' }
+  | { type: 'RECEIVE_CONTINUE' }
+  | { type: 'RECEIVE_CLOSE' }
   | { type: 'TASK_FAIL' }
   | { type: 'RECEIVE_ERROR' }
   | { type: 'CANCEL' };
@@ -88,6 +92,15 @@ export class AssignmentStateMachine {
       case 'TASK_COMPLETE':
         return this.state === 'active' ? 'completed' : null;
 
+      case 'ROUND_COMPLETE':
+        return this.state === 'active' ? 'idle' : null;
+
+      case 'RECEIVE_CONTINUE':
+        return this.state === 'idle' ? 'active' : null;
+
+      case 'RECEIVE_CLOSE':
+        return this.state === 'idle' ? 'completed' : null;
+
       case 'TASK_FAIL':
         return this.state === 'active' ? 'error' : null;
 
@@ -116,6 +129,12 @@ export function createAssignment(params: {
     invite: params.invite,
     workPath: params.workPath,
     retentionMs: params.retentionMs,
+    currentRound: 1,
+    rounds: [{
+      number: 1,
+      task: params.invite.task,
+      startedAt: now,
+    }],
     createdAt: now,
     updatedAt: now,
   };

--- a/packages/core/src/state-machine/delegation.ts
+++ b/packages/core/src/state-machine/delegation.ts
@@ -7,6 +7,7 @@ import type {
   StartMessage,
   DoneMessage,
   ErrorMessage,
+  ContinueMessage,
 } from '../types/messages.js';
 
 // ========== Transition Table ==========
@@ -16,7 +17,8 @@ const DELEGATION_TRANSITIONS: Record<DelegationState, DelegationState[]> = {
   invited: ['accepted', 'error', 'cancelled', 'expired'],
   accepted: ['started', 'error', 'cancelled', 'expired'],
   started: ['running', 'error', 'cancelled'],
-  running: ['completed', 'error', 'cancelled', 'expired'],
+  running: ['idle', 'completed', 'error', 'cancelled', 'expired'],
+  idle: ['running', 'completed', 'error', 'cancelled'],
   completed: [],
   error: [],
   cancelled: [],
@@ -41,11 +43,14 @@ export type DelegationEvent =
   | { type: 'RECEIVE_ACCEPT'; message: AcceptMessage }
   | { type: 'SEND_START'; message: StartMessage }
   | { type: 'SETUP_COMPLETE' }
+  | { type: 'ROUND_COMPLETE' }
+  | { type: 'SEND_CONTINUE'; message: ContinueMessage }
+  | { type: 'SEND_CLOSE' }
   | { type: 'RECEIVE_DONE'; message: DoneMessage }
   | { type: 'RECEIVE_ERROR'; message: ErrorMessage }
   | { type: 'SEND_ERROR'; message: ErrorMessage }
   | { type: 'CANCEL' }
-  | { type: 'EXPIRE' };  // TODO: Implement lease expiration timer
+  | { type: 'EXPIRE' };
 
 export interface TransitionResult {
   success: boolean;
@@ -111,6 +116,15 @@ export class DelegationStateMachine {
       
       case 'SETUP_COMPLETE':
         return this.state === 'started' ? 'running' : null;
+
+      case 'ROUND_COMPLETE':
+        return this.state === 'running' ? 'idle' : null;
+
+      case 'SEND_CONTINUE':
+        return this.state === 'idle' ? 'running' : null;
+
+      case 'SEND_CLOSE':
+        return this.state === 'idle' ? 'completed' : null;
       
       case 'RECEIVE_DONE':
         return this.state === 'running' ? 'completed' : null;
@@ -123,7 +137,7 @@ export class DelegationStateMachine {
         return isTerminalState(this.state) ? null : 'cancelled';
       
       case 'EXPIRE':
-        return ['invited', 'accepted', 'running'].includes(this.state)
+        return ['invited', 'accepted', 'running', 'idle'].includes(this.state)
           ? 'expired'
           : null;
       
@@ -156,6 +170,12 @@ export function createDelegation(params: {
     retentionMs: params.retentionMs,
     snapshotPolicy: params.snapshotPolicy,
     exportPath: params.exportPath,
+    currentRound: 1,
+    rounds: [{
+      number: 1,
+      task: params.task,
+      startedAt: now,
+    }],
     createdAt: now,
     updatedAt: now,
   };

--- a/packages/core/src/types/messages.ts
+++ b/packages/core/src/types/messages.ts
@@ -1,6 +1,6 @@
 export const PROTOCOL_VERSION = '1' as const;
 
-export type MessageType = 'INVITE' | 'ACCEPT' | 'START' | 'DONE' | 'ERROR';
+export type MessageType = 'INVITE' | 'ACCEPT' | 'START' | 'DONE' | 'ERROR' | 'CONTINUE' | 'CLOSE';
 
 export type AccessMode = 'ro' | 'rw';
 
@@ -51,6 +51,7 @@ export type DelegationState =
   | 'accepted'
   | 'started'
   | 'running'
+  | 'idle'
   | 'completed'
   | 'error'
   | 'cancelled'
@@ -190,18 +191,33 @@ export interface ErrorMessage extends BaseMessage {
   hint?: string;
 }
 
+/** CONTINUE message: Delegator → Executor (start a new round with updated instructions) */
+export interface ContinueMessage extends BaseMessage {
+  type: 'CONTINUE';
+  task: TaskSpec;
+  round: number;
+  lease?: ActiveLease;
+}
+
+/** CLOSE message: Delegator → Executor (end the multi-round session) */
+export interface CloseMessage extends BaseMessage {
+  type: 'CLOSE';
+}
+
 export type AwcpMessage =
   | InviteMessage
   | AcceptMessage
   | StartMessage
   | DoneMessage
-  | ErrorMessage;
+  | ErrorMessage
+  | ContinueMessage
+  | CloseMessage;
 
 // --- Task Events (SSE Streaming) ---
 
 import type { SnapshotMetadata } from './snapshot.js';
 
-export type TaskEventType = 'status' | 'snapshot' | 'done' | 'error';
+export type TaskEventType = 'status' | 'snapshot' | 'done' | 'error' | 'round_done';
 
 export interface BaseTaskEvent {
   delegationId: string;
@@ -242,11 +258,32 @@ export interface TaskErrorEvent extends BaseTaskEvent {
   hint?: string;
 }
 
-export type TaskEvent = TaskStatusEvent | TaskSnapshotEvent | TaskDoneEvent | TaskErrorEvent;
+export interface TaskRoundDoneEvent extends BaseTaskEvent {
+  type: 'round_done';
+  round: number;
+  summary: string;
+  highlights?: string[];
+  snapshotIds?: string[];
+  recommendedSnapshotId?: string;
+}
+
+export type TaskEvent = TaskStatusEvent | TaskSnapshotEvent | TaskDoneEvent | TaskErrorEvent | TaskRoundDoneEvent;
 
 // --- Delegation Record ---
 
 import type { EnvironmentSnapshot, SnapshotPolicy } from './snapshot.js';
+
+export interface Round {
+  number: number;
+  task: TaskSpec;
+  result?: {
+    summary: string;
+    highlights?: string[];
+  };
+  snapshots?: EnvironmentSnapshot[];
+  startedAt: string;
+  completedAt?: string;
+}
 
 export interface Delegation {
   id: string;
@@ -264,6 +301,8 @@ export interface Delegation {
   snapshots?: EnvironmentSnapshot[];
   appliedSnapshotId?: string;
   snapshotPolicy?: SnapshotPolicy;
+  currentRound: number;
+  rounds: Round[];
   result?: {
     summary: string;
     highlights?: string[];
@@ -279,7 +318,7 @@ export interface Delegation {
 
 // --- Assignment Record ---
 
-export type AssignmentState = 'pending' | 'active' | 'completed' | 'error';
+export type AssignmentState = 'pending' | 'active' | 'idle' | 'completed' | 'error';
 
 export interface Assignment {
   id: string;
@@ -288,6 +327,8 @@ export interface Assignment {
   workPath: string;
   retentionMs: number;
   lease?: ActiveLease;
+  currentRound: number;
+  rounds: Round[];
   startedAt?: string;
   completedAt?: string;
   result?: {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -7,6 +7,8 @@
  * - delegate: Initiate a workspace delegation
  * - delegate_output: Get delegation status/results
  * - delegate_cancel: Cancel active delegations
+ * - delegate_continue: Send new instructions to an idle delegation (multi-round)
+ * - delegate_close: End a multi-round delegation session
  * - delegate_snapshots: List snapshots for a delegation
  * - delegate_apply_snapshot: Apply a staged snapshot
  * - delegate_discard_snapshot: Discard a staged snapshot
@@ -53,6 +55,16 @@ import {
   delegateRecoverDescription,
   type DelegateRecoverParams,
 } from './tools/delegate-recover.js';
+import {
+  delegateContinueSchema,
+  delegateContinueDescription,
+  type DelegateContinueParams,
+} from './tools/delegate-continue.js';
+import {
+  delegateCloseSchema,
+  delegateCloseDescription,
+  type DelegateCloseParams,
+} from './tools/delegate-close.js';
 import { type PeersContext } from './peer-discovery.js';
 
 export interface AwcpMcpServerOptions {
@@ -395,6 +407,93 @@ Use \`delegate_output(delegation_id="${delegationId}")\` to check progress or re
     }
   );
 
+  // ============================================
+  // Tool: delegate_continue
+  // ============================================
+  server.tool(
+    'delegate_continue',
+    delegateContinueDescription,
+    delegateContinueSchema.shape,
+    async (params: DelegateContinueParams) => {
+      const { delegation_id, description, prompt, background } = params;
+
+      try {
+        await client.continueDelegation(delegation_id, { description, prompt });
+
+        if (background) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Continuation round started in background.
+
+Delegation ID: ${delegation_id}
+Task: ${description}
+Status: running
+
+Use \`delegate_output(delegation_id="${delegation_id}")\` to check progress.`,
+            }],
+          };
+        }
+
+        const delegation = await client.waitForIdle(delegation_id, 2000, 3600000);
+
+        if (delegation.state === 'idle') {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: formatRoundResult(delegation),
+            }],
+          };
+        }
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: formatDelegationResult(delegation),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Continue failed: ${error instanceof Error ? error.message : String(error)}`,
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ============================================
+  // Tool: delegate_close
+  // ============================================
+  server.tool(
+    'delegate_close',
+    delegateCloseDescription,
+    delegateCloseSchema.shape,
+    async (params: DelegateCloseParams) => {
+      const { delegation_id } = params;
+
+      try {
+        await client.closeDelegation(delegation_id);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Delegation ${delegation_id} closed. Workspace and transport cleaned up.`,
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Close failed: ${error instanceof Error ? error.message : String(error)}`,
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
   return server;
 }
 
@@ -436,7 +535,33 @@ function isTerminalState(state: string): boolean {
 }
 
 function isRunning(delegation: Delegation): boolean {
-  return !isTerminalState(delegation.state);
+  return !isTerminalState(delegation.state) && delegation.state !== 'idle';
+}
+
+function formatRoundResult(delegation: Delegation): string {
+  const lastRound = delegation.rounds?.[delegation.rounds.length - 1];
+  const lines: string[] = [
+    `Delegation: ${delegation.id}`,
+    `Status: idle (round ${delegation.currentRound} complete)`,
+  ];
+
+  if (lastRound?.result) {
+    lines.push('', '--- Round Result ---', lastRound.result.summary);
+    if (lastRound.result.highlights?.length) {
+      lines.push('', 'Highlights:', ...lastRound.result.highlights.map(h => `  - ${h}`));
+    }
+  }
+
+  const pendingSnapshots = delegation.snapshots?.filter(s => s.status === 'pending') ?? [];
+  if (pendingSnapshots.length > 0) {
+    lines.push('', `${pendingSnapshots.length} pending snapshot(s) - use delegate_snapshots to review`);
+  }
+
+  lines.push('', 'Next steps:');
+  lines.push(`  - delegate_continue(delegation_id="${delegation.id}", ...) to iterate further`);
+  lines.push(`  - delegate_close(delegation_id="${delegation.id}") to end the session`);
+
+  return lines.join('\n');
 }
 
 function formatBytes(bytes: number | undefined): string {
@@ -452,10 +577,22 @@ function formatDelegationResult(delegation: Delegation): string {
     `Status: ${delegation.state}`,
   ];
 
+  if (delegation.rounds?.length > 1) {
+    lines.push(`Rounds completed: ${delegation.rounds.length}`);
+  }
+
   if (delegation.state === 'completed' && delegation.result) {
     lines.push('', '--- Result ---', delegation.result.summary);
     if (delegation.result.highlights?.length) {
       lines.push('', 'Highlights:', ...delegation.result.highlights.map((h: string) => `  - ${h}`));
+    }
+
+    if (delegation.rounds?.length > 1) {
+      lines.push('', '--- Round History ---');
+      for (const round of delegation.rounds) {
+        const roundResult = round.result?.summary ?? '(no result)';
+        lines.push(`  Round ${round.number}: ${roundResult}`);
+      }
     }
 
     const pendingSnapshots = delegation.snapshots?.filter(s => s.status === 'pending') ?? [];
@@ -484,6 +621,10 @@ function formatDelegationStatus(delegation: Delegation): string {
     `Created: ${delegation.createdAt}`,
   ];
 
+  if (delegation.currentRound > 1 || delegation.state === 'idle') {
+    lines.push(`Current round: ${delegation.currentRound}`);
+  }
+
   if (delegation.snapshotPolicy) {
     lines.push(`Snapshot mode: ${delegation.snapshotPolicy.mode}`);
   }
@@ -495,7 +636,19 @@ function formatDelegationStatus(delegation: Delegation): string {
     lines.push(`Snapshots: ${delegation.snapshots.length} total (${applied} applied, ${pending} pending, ${discarded} discarded)`);
   }
 
-  if (isRunning(delegation)) {
+  if (delegation.state === 'idle') {
+    const lastRound = delegation.rounds?.[delegation.rounds.length - 1];
+    lines.push('', 'Round complete — delegation is idle, awaiting next action.');
+    if (lastRound?.result) {
+      lines.push('', `--- Round ${lastRound.number} Result ---`, lastRound.result.summary);
+      if (lastRound.result.highlights?.length) {
+        lines.push('', 'Highlights:', ...lastRound.result.highlights.map(h => `  - ${h}`));
+      }
+    }
+    lines.push('', 'Next steps:');
+    lines.push(`  - delegate_continue(delegation_id="${delegation.id}", ...) to start another round`);
+    lines.push(`  - delegate_close(delegation_id="${delegation.id}") to end the session`);
+  } else if (isRunning(delegation)) {
     lines.push('', 'Task is still running...');
   } else if (delegation.state === 'completed') {
     if (delegation.result) {
@@ -518,6 +671,15 @@ function formatDelegationStatus(delegation: Delegation): string {
     }
   } else if (delegation.state === 'cancelled') {
     lines.push('', 'Delegation was cancelled.');
+  }
+
+  if (delegation.rounds?.length > 1) {
+    lines.push('', '--- Round History ---');
+    for (const round of delegation.rounds) {
+      const status = round.completedAt ? 'done' : 'in progress';
+      const result = round.result?.summary ?? `(${status})`;
+      lines.push(`  Round ${round.number}: ${result}`);
+    }
   }
 
   return lines.join('\n');

--- a/packages/mcp/src/tools/delegate-close.ts
+++ b/packages/mcp/src/tools/delegate-close.ts
@@ -1,0 +1,18 @@
+/**
+ * delegate_close tool - End a multi-round delegation session
+ *
+ * Use this to clean up after all rounds are complete.
+ */
+
+import { z } from 'zod';
+
+export const delegateCloseSchema = z.object({
+  delegation_id: z
+    .string()
+    .describe('The delegation to close'),
+});
+
+export type DelegateCloseParams = z.infer<typeof delegateCloseSchema>;
+
+export const delegateCloseDescription =
+  'End a multi-round delegation session. This cleans up the workspace, transport connection, and environment. Use this when all rounds are complete and no more iterations are needed.';

--- a/packages/mcp/src/tools/delegate-continue.ts
+++ b/packages/mcp/src/tools/delegate-continue.ts
@@ -1,0 +1,28 @@
+/**
+ * delegate_continue tool - Send new instructions to an idle delegation
+ *
+ * Use this to start a new round in a multi-round delegation session.
+ */
+
+import { z } from 'zod';
+
+export const delegateContinueSchema = z.object({
+  delegation_id: z
+    .string()
+    .describe('The delegation to continue'),
+  description: z
+    .string()
+    .describe('Short task description for logs'),
+  prompt: z
+    .string()
+    .describe('Full updated task instructions'),
+  background: z
+    .boolean()
+    .optional()
+    .describe('If true, return immediately (default: false, wait for round completion)'),
+});
+
+export type DelegateContinueParams = z.infer<typeof delegateContinueSchema>;
+
+export const delegateContinueDescription =
+  'Send new instructions to an existing delegation in idle state. Use this when the previous round\'s results need adjustments. The executor keeps the workspace from previous rounds — no data is re-transferred.';

--- a/packages/sdk/src/delegator/bin/client.ts
+++ b/packages/sdk/src/delegator/bin/client.ts
@@ -114,6 +114,48 @@ export class DelegatorDaemonClient {
     await this.request(`/delegation/${delegationId}`, { method: 'DELETE' });
   }
 
+  async continueDelegation(delegationId: string, task: TaskSpec): Promise<void> {
+    await this.request(`/delegation/${delegationId}/continue`, {
+      method: 'POST',
+      body: { task },
+    });
+  }
+
+  async closeDelegation(delegationId: string): Promise<void> {
+    await this.request(`/delegation/${delegationId}/close`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Wait for a delegation to reach idle state (round complete) or terminal state.
+   * Used by delegate_continue to wait for the current round to finish.
+   */
+  async waitForIdle(
+    delegationId: string,
+    pollIntervalMs: number = 1000,
+    timeoutMs: number = 60000
+  ): Promise<Delegation> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      const delegation = await this.getDelegation(delegationId);
+
+      if (
+        delegation.state === 'idle' ||
+        delegation.state === 'completed' ||
+        delegation.state === 'error' ||
+        delegation.state === 'cancelled'
+      ) {
+        return delegation;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new Error(`Timeout waiting for delegation ${delegationId} to reach idle state`);
+  }
+
   /**
    * Wait for a delegation to complete
    */

--- a/packages/sdk/src/delegator/bin/daemon.ts
+++ b/packages/sdk/src/delegator/bin/daemon.ts
@@ -129,6 +129,39 @@ export async function startDelegatorDaemon(config: DaemonConfig): Promise<Daemon
   });
 
   /**
+   * POST /delegation/:id/continue - Continue delegation with new instructions
+   */
+  app.post('/delegation/:id/continue', async (req, res) => {
+    try {
+      const { task } = req.body;
+      if (!task) {
+        res.status(400).json({ error: 'Missing required field: task' });
+        return;
+      }
+      await service.continue({ delegationId: req.params.id, task });
+      res.json({ ok: true, round: service.getDelegation(req.params.id)?.currentRound });
+    } catch (error) {
+      res.status(400).json({
+        error: error instanceof Error ? error.message : 'Failed to continue',
+      });
+    }
+  });
+
+  /**
+   * POST /delegation/:id/close - Close a multi-round delegation session
+   */
+  app.post('/delegation/:id/close', async (req, res) => {
+    try {
+      await service.close(req.params.id);
+      res.json({ ok: true });
+    } catch (error) {
+      res.status(400).json({
+        error: error instanceof Error ? error.message : 'Failed to close',
+      });
+    }
+  });
+
+  /**
    * GET /delegation/:id/snapshots - List snapshots for a delegation
    */
   app.get('/delegation/:id/snapshots', (req, res) => {

--- a/packages/sdk/src/delegator/config.ts
+++ b/packages/sdk/src/delegator/config.ts
@@ -11,6 +11,7 @@ import type {
   EnvironmentSpec,
   TaskSpec,
   AuthCredential,
+  Round,
 } from '@awcp/core';
 
 // ========== Admission ==========
@@ -56,6 +57,13 @@ export interface DelegateParams {
   auth?: AuthCredential;
 }
 
+// ========== Continue Params ==========
+
+export interface ContinueParams {
+  delegationId: string;
+  task: TaskSpec;
+}
+
 // ========== Hooks ==========
 
 export interface DelegatorHooks {
@@ -63,6 +71,7 @@ export interface DelegatorHooks {
   onDelegationCreated?: (delegation: Delegation) => void;
   onDelegationStarted?: (delegation: Delegation) => void;
   onDelegationCompleted?: (delegation: Delegation) => void;
+  onRoundCompleted?: (delegation: Delegation, round: Round) => void;
   onSnapshotReceived?: (delegation: Delegation, snapshot: EnvironmentSnapshot) => void;
   onSnapshotApplied?: (delegation: Delegation, snapshot: EnvironmentSnapshot) => void;
   onError?: (delegationId: string, error: Error) => void;

--- a/packages/sdk/src/delegator/executor-client.ts
+++ b/packages/sdk/src/delegator/executor-client.ts
@@ -2,7 +2,7 @@
  * HTTP Client for sending AWCP messages to Executor
  */
 
-import type { AwcpMessage, AcceptMessage, ErrorMessage, TaskEvent } from '@awcp/core';
+import type { AwcpMessage, AcceptMessage, ErrorMessage, TaskEvent, ContinueMessage, CloseMessage } from '@awcp/core';
 
 export type InviteResponse = AcceptMessage | ErrorMessage;
 
@@ -102,6 +102,7 @@ export class ExecutorClient {
                 if (event.type === 'done' || event.type === 'error') {
                   return;
                 }
+                // round_done does NOT terminate the stream
               } catch {
                 // Ignore parse errors
               }
@@ -112,6 +113,14 @@ export class ExecutorClient {
     } finally {
       reader.releaseLock();
     }
+  }
+
+  async sendContinue(executorUrl: string, message: ContinueMessage): Promise<void> {
+    await this.send(executorUrl, message);
+  }
+
+  async sendClose(executorUrl: string, message: CloseMessage): Promise<void> {
+    await this.send(executorUrl, message);
   }
 
   async sendCancel(executorUrl: string, delegationId: string): Promise<void> {

--- a/packages/sdk/src/delegator/service.ts
+++ b/packages/sdk/src/delegator/service.ts
@@ -13,9 +13,12 @@ import {
   type AcceptMessage,
   type DoneMessage,
   type ErrorMessage,
+  type ContinueMessage,
+  type CloseMessage,
   type DelegatorTransportAdapter,
   type TaskEvent,
   type TaskSnapshotEvent,
+  type TaskRoundDoneEvent,
   type EnvironmentSnapshot,
   type EnvironmentSpec,
   DelegationStateMachine,
@@ -28,7 +31,7 @@ import {
   WorkspaceNotFoundError,
   WorkspaceInvalidError,
 } from '@awcp/core';
-import { type DelegatorConfig, type ResolvedDelegatorConfig, type DelegateParams, resolveDelegatorConfig } from './config.js';
+import { type DelegatorConfig, type ResolvedDelegatorConfig, type DelegateParams, type ContinueParams, resolveDelegatorConfig } from './config.js';
 import { AdmissionController } from './admission.js';
 import { DelegationManager } from './delegation-manager.js';
 import { EnvironmentManager } from './environment-manager.js';
@@ -50,6 +53,8 @@ export interface DelegatorServiceStatus {
 
 export interface DelegatorRequestHandler {
   delegate(params: DelegateParams): Promise<string>;
+  continue(params: ContinueParams): Promise<void>;
+  close(delegationId: string): Promise<void>;
   cancel(delegationId: string): Promise<void>;
   getDelegation(delegationId: string): Delegation | undefined;
   getStatus(): DelegatorServiceStatus;
@@ -69,6 +74,7 @@ export class DelegatorService implements DelegatorRequestHandler {
   private executorClient: ExecutorClient;
   private delegations = new Map<string, Delegation>();
   private stateMachines = new Map<string, DelegationStateMachine>();
+  private activeStreams = new Map<string, TaskEventStream>();
   private cleanupTimer?: ReturnType<typeof setInterval>;
 
   constructor(options: DelegatorServiceOptions) {
@@ -147,6 +153,11 @@ export class DelegatorService implements DelegatorRequestHandler {
       this.cleanupTimer = undefined;
     }
 
+    for (const stream of this.activeStreams.values()) {
+      stream.abort();
+    }
+    this.activeStreams.clear();
+
     await this.transport.shutdown?.();
 
     this.delegations.clear();
@@ -196,6 +207,12 @@ export class DelegatorService implements DelegatorRequestHandler {
         const delegation = this.delegations.get(delegationId)!;
         delegation.state = 'created';
         delegation.exportPath = envRoot;
+        delegation.currentRound = 1;
+        delegation.rounds = [{
+          number: 1,
+          task: params.task,
+          startedAt: new Date().toISOString(),
+        }];
       } else {
         const delegation = createDelegation({
           id: delegationId,
@@ -308,6 +325,7 @@ export class DelegatorService implements DelegatorRequestHandler {
       };
 
       stream = await this.executorClient.connectTaskEvents(delegation.peerUrl, delegation.id);
+      this.activeStreams.set(delegation.id, stream);
 
       this.transitionState(delegation.id, { type: 'SEND_START', message: startMessage });
       delegation.activeLease = startMessage.lease;
@@ -348,12 +366,129 @@ export class DelegatorService implements DelegatorRequestHandler {
       summary: message.finalSummary,
       highlights: message.highlights,
     };
+
+    const currentRound = delegation.rounds[delegation.rounds.length - 1];
+    if (currentRound && !currentRound.completedAt) {
+      currentRound.completedAt = new Date().toISOString();
+      currentRound.result = delegation.result;
+    }
+
     await this.persistDelegation(delegation.id);
 
+    this.activeStreams.delete(delegation.id);
     await this.transport.detach(delegation.id).catch(() => {});
     await this.environmentManager.release(delegation.id);
 
     this.config.hooks.onDelegationCompleted?.(delegation);
+  }
+
+  private async handleRoundDone(delegationId: string, event: TaskRoundDoneEvent): Promise<void> {
+    const delegation = this.delegations.get(delegationId);
+    if (!delegation) return;
+
+    this.transitionState(delegationId, { type: 'ROUND_COMPLETE' });
+
+    const currentRound = delegation.rounds[delegation.rounds.length - 1];
+    if (currentRound) {
+      currentRound.completedAt = new Date().toISOString();
+      currentRound.result = {
+        summary: event.summary,
+        highlights: event.highlights,
+      };
+    }
+
+    delegation.result = {
+      summary: event.summary,
+      highlights: event.highlights,
+    };
+
+    await this.persistDelegation(delegationId);
+
+    this.config.hooks.onRoundCompleted?.(delegation, currentRound ?? {
+      number: event.round,
+      task: delegation.task,
+      startedAt: delegation.createdAt,
+      completedAt: new Date().toISOString(),
+      result: { summary: event.summary, highlights: event.highlights },
+    });
+  }
+
+  async continue(params: ContinueParams): Promise<void> {
+    const delegation = this.delegations.get(params.delegationId);
+    if (!delegation) {
+      throw new Error(`Unknown delegation: ${params.delegationId}`);
+    }
+
+    const sm = this.stateMachines.get(params.delegationId)!;
+    if (sm.getState() !== 'idle') {
+      throw new Error(
+        `Cannot continue delegation ${params.delegationId} in state '${sm.getState()}', expected 'idle'`
+      );
+    }
+
+    const round = delegation.currentRound + 1;
+    delegation.currentRound = round;
+    delegation.rounds.push({
+      number: round,
+      task: params.task,
+      startedAt: new Date().toISOString(),
+    });
+
+    const continueMessage: ContinueMessage = {
+      version: PROTOCOL_VERSION,
+      type: 'CONTINUE',
+      delegationId: params.delegationId,
+      task: params.task,
+      round,
+    };
+
+    this.transitionState(params.delegationId, { type: 'SEND_CONTINUE', message: continueMessage });
+
+    await this.executorClient.sendContinue(delegation.peerUrl, continueMessage);
+    await this.persistDelegation(params.delegationId);
+
+    console.log(`[AWCP:Delegator] CONTINUE sent for ${params.delegationId} (round ${round})`);
+  }
+
+  async close(delegationId: string): Promise<void> {
+    const delegation = this.delegations.get(delegationId);
+    if (!delegation) {
+      throw new Error(`Unknown delegation: ${delegationId}`);
+    }
+
+    const sm = this.stateMachines.get(delegationId)!;
+    if (sm.getState() !== 'idle') {
+      throw new Error(
+        `Cannot close delegation ${delegationId} in state '${sm.getState()}', expected 'idle'`
+      );
+    }
+
+    this.transitionState(delegationId, { type: 'SEND_CLOSE' });
+
+    const closeMessage: CloseMessage = {
+      version: PROTOCOL_VERSION,
+      type: 'CLOSE',
+      delegationId,
+    };
+
+    try {
+      await this.executorClient.sendClose(delegation.peerUrl, closeMessage);
+    } catch (error) {
+      console.error(`[AWCP:Delegator] Failed to send CLOSE for ${delegationId}, cleaning up directly:`, error);
+    }
+
+    const stream = this.activeStreams.get(delegationId);
+    if (stream) {
+      stream.abort();
+      this.activeStreams.delete(delegationId);
+    }
+
+    await this.persistDelegation(delegationId);
+    await this.transport.release(delegationId).catch(() => {});
+    await this.environmentManager.release(delegationId);
+
+    this.config.hooks.onDelegationCompleted?.(delegation);
+    console.log(`[AWCP:Delegator] Session closed for ${delegationId}`);
   }
 
   async handleError(message: ErrorMessage): Promise<void> {
@@ -431,6 +566,10 @@ export class DelegatorService implements DelegatorRequestHandler {
       await this.handleSnapshotEvent(delegationId, event);
     }
 
+    if (event.type === 'round_done') {
+      await this.handleRoundDone(delegationId, event);
+    }
+
     if (event.type === 'done') {
       await this.executorClient.acknowledgeResult(delegation.peerUrl, delegationId).catch(() => {});
 
@@ -480,6 +619,12 @@ export class DelegatorService implements DelegatorRequestHandler {
     }
 
     this.transitionState(delegationId, { type: 'CANCEL' });
+
+    const stream = this.activeStreams.get(delegationId);
+    if (stream) {
+      stream.abort();
+      this.activeStreams.delete(delegationId);
+    }
 
     await this.persistDelegation(delegationId);
     await this.executorClient.sendCancel(delegation.peerUrl, delegationId).catch(console.error);

--- a/packages/sdk/src/delegator/service.ts
+++ b/packages/sdk/src/delegator/service.ts
@@ -165,10 +165,19 @@ export class DelegatorService implements DelegatorRequestHandler {
           ` (known=[${Array.from(this.delegations.keys()).join(',')}])`
         );
       }
+
       if (isTerminalState(existing.state)) {
-        throw new Error(
-          `Cannot resume terminal delegation: ${delegationId} (state=${existing.state})`
+        console.log(
+          `[AWCP:Delegator] Re-delegating from terminal state ${delegationId} (was ${existing.state})`
         );
+        existing.result = undefined;
+        existing.error = undefined;
+        existing.activeLease = undefined;
+        existing.executorWorkDir = undefined;
+        existing.executorConstraints = undefined;
+        existing.executorRetentionMs = undefined;
+        existing.snapshots = undefined;
+        existing.appliedSnapshotId = undefined;
       }
 
       await this.transport.detach(delegationId).catch(() => {});

--- a/packages/sdk/src/delegator/service.ts
+++ b/packages/sdk/src/delegator/service.ts
@@ -165,19 +165,10 @@ export class DelegatorService implements DelegatorRequestHandler {
           ` (known=[${Array.from(this.delegations.keys()).join(',')}])`
         );
       }
-
       if (isTerminalState(existing.state)) {
-        console.log(
-          `[AWCP:Delegator] Re-delegating from terminal state ${delegationId} (was ${existing.state})`
+        throw new Error(
+          `Cannot resume terminal delegation: ${delegationId} (state=${existing.state})`
         );
-        existing.result = undefined;
-        existing.error = undefined;
-        existing.activeLease = undefined;
-        existing.executorWorkDir = undefined;
-        existing.executorConstraints = undefined;
-        existing.executorRetentionMs = undefined;
-        existing.snapshots = undefined;
-        existing.appliedSnapshotId = undefined;
       }
 
       await this.transport.detach(delegationId).catch(() => {});

--- a/packages/sdk/src/executor/service.ts
+++ b/packages/sdk/src/executor/service.ts
@@ -7,6 +7,8 @@ import { join } from 'node:path';
 import {
   type InviteMessage,
   type StartMessage,
+  type ContinueMessage,
+  type CloseMessage,
   type AcceptMessage,
   type ErrorMessage,
   type AwcpMessage,
@@ -17,7 +19,9 @@ import {
   type TaskStatusEvent,
   type TaskSnapshotEvent,
   type TaskDoneEvent,
+  type TaskRoundDoneEvent,
   type TaskErrorEvent,
+  type TaskSpec,
   type AssignmentEvent,
   AssignmentStateMachine,
   isTerminalAssignmentState,
@@ -116,6 +120,12 @@ export class ExecutorService implements ExecutorRequestHandler {
         case 'START':
           await this.handleStart(message);
           return null;
+        case 'CONTINUE':
+          await this.handleContinue(message);
+          return null;
+        case 'CLOSE':
+          await this.handleClose(message);
+          return null;
         case 'ERROR':
           await this.handleError(message);
           return null;
@@ -148,6 +158,13 @@ export class ExecutorService implements ExecutorRequestHandler {
       existing.state = 'pending';
       existing.invite = invite;
       existing.retentionMs = retentionMs;
+      existing.error = undefined;
+      existing.currentRound = 1;
+      existing.rounds = [{
+        number: 1,
+        task: invite.task,
+        startedAt: new Date().toISOString(),
+      }];
 
       this.stateMachines.set(delegationId, new AssignmentStateMachine());
       this.eventEmitters.set(delegationId, new EventEmitter());
@@ -256,6 +273,70 @@ export class ExecutorService implements ExecutorRequestHandler {
     );
   }
 
+  private async handleContinue(message: ContinueMessage): Promise<void> {
+    const { delegationId } = message;
+    const assignment = this.assignments.get(delegationId);
+    if (!assignment) {
+      throw new Error(`Unknown delegation for CONTINUE: ${delegationId} (known=[${Array.from(this.assignments.keys()).join(',')}])`);
+    }
+
+    this.transitionState(delegationId, { type: 'RECEIVE_CONTINUE' });
+
+    // Save current round result if exists
+    const currentRound = assignment.rounds[assignment.rounds.length - 1];
+    if (currentRound && !currentRound.completedAt) {
+      currentRound.completedAt = new Date().toISOString();
+    }
+
+    // Start new round
+    assignment.currentRound = message.round;
+    assignment.rounds.push({
+      number: message.round,
+      task: message.task,
+      startedAt: new Date().toISOString(),
+    });
+
+    if (message.lease) {
+      assignment.lease = message.lease;
+    }
+
+    await this.persistAssignment(delegationId);
+
+    console.log(`[AWCP:Executor] Starting round ${message.round} for ${delegationId}`);
+
+    // Execute on existing workspace — NO transport.setup() needed
+    this.executeRound(delegationId, message.task, message.round);
+  }
+
+  private async handleClose(message: CloseMessage): Promise<void> {
+    const { delegationId } = message;
+    const assignment = this.assignments.get(delegationId);
+    if (!assignment) {
+      throw new Error(`Unknown delegation for CLOSE: ${delegationId}`);
+    }
+
+    this.transitionState(delegationId, { type: 'RECEIVE_CLOSE' });
+
+    assignment.completedAt = new Date().toISOString();
+    await this.persistAssignment(delegationId);
+
+    // Emit done event to close SSE stream
+    const emitter = this.eventEmitters.get(delegationId);
+    if (emitter) {
+      const doneEvent: TaskDoneEvent = {
+        delegationId,
+        type: 'done',
+        timestamp: new Date().toISOString(),
+        summary: 'Session closed by delegator',
+      };
+      emitter.emit('event', doneEvent);
+    }
+
+    // Final cleanup — use release() (not detach()) to fully tear down transport
+    await this.transport.release({ delegationId, localPath: assignment.workPath }).catch(() => {});
+    console.log(`[AWCP:Executor] Session closed for ${delegationId}`);
+  }
+
   subscribeTask(delegationId: string, callback: (event: TaskEvent) => void): () => void {
     const assignment = this.assignments.get(delegationId);
     if (!assignment) {
@@ -317,6 +398,9 @@ export class ExecutorService implements ExecutorRequestHandler {
         localPath: assignment.workPath,
       });
 
+      // Store actualPath for later rounds
+      assignment.workPath = actualPath;
+
       this.config.hooks.onTaskStart?.({
         delegationId,
         workPath: actualPath,
@@ -325,26 +409,68 @@ export class ExecutorService implements ExecutorRequestHandler {
         environment: assignment.invite.environment,
       });
 
-      console.log(`[AWCP:Executor] Task ${delegationId} executing (listeners=${emitter.listenerCount('event')})...`);
+      console.log(`[AWCP:Executor] Task ${delegationId} executing round 1 (listeners=${emitter.listenerCount('event')})...`);
+
+      // Delegate to _doRound for the actual execution
+      await this._doRound(delegationId, assignment.invite.task, 1);
+
+    } catch (error) {
+      // Transport setup or workspace prep failed
+      console.error(`[AWCP:Executor] Task ${delegationId} setup failed:`, error instanceof Error ? error.message : error);
+
+      const errorEvent: TaskErrorEvent = {
+        delegationId,
+        type: 'error',
+        timestamp: new Date().toISOString(),
+        code: ErrorCodes.TASK_FAILED,
+        message: error instanceof Error ? error.message : String(error),
+        hint: 'Check task requirements and try again',
+      };
+      emitter.emit('event', errorEvent);
+
+      this.transitionState(delegationId, { type: 'TASK_FAIL' });
+      assignment.completedAt = new Date().toISOString();
+      assignment.error = {
+        code: ErrorCodes.TASK_FAILED,
+        message: error instanceof Error ? error.message : String(error),
+      };
+      await this.persistAssignment(delegationId);
+      await this.transport.detach({ delegationId, localPath: assignment.workPath }).catch(() => {});
+      this.config.hooks.onError?.(delegationId, error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  private executeRound(delegationId: string, task: TaskSpec, round: number): void {
+    // This runs the executor on the EXISTING workspace, no transport setup
+    // Fire and forget (async)
+    this._doRound(delegationId, task, round).catch((error) => {
+      console.error(`[AWCP:Executor] Round ${round} failed for ${delegationId}:`, error);
+    });
+  }
+
+  private async _doRound(delegationId: string, task: TaskSpec, round: number): Promise<void> {
+    const assignment = this.assignments.get(delegationId)!;
+    const emitter = this.eventEmitters.get(delegationId)!;
+
+    try {
       const statusEvent: TaskStatusEvent = {
         delegationId,
         type: 'status',
         timestamp: new Date().toISOString(),
         status: 'running',
-        message: 'Task execution started',
+        message: `Round ${round} execution started`,
       };
       emitter.emit('event', statusEvent);
 
       const result = await this.executor.execute({
         delegationId,
-        workPath: actualPath,
-        task: assignment.invite.task,
+        workPath: assignment.workPath,
+        task,
         environment: assignment.invite.environment,
       });
 
-      console.log(`[AWCP:Executor] Task ${delegationId} completed, capturing snapshot...`);
-      const snapshotResult = await this.transport.captureSnapshot?.({ delegationId, localPath: actualPath });
-
+      // Capture snapshot
+      const snapshotResult = await this.transport.captureSnapshot?.({ delegationId, localPath: assignment.workPath });
       const snapshotId = generateSnapshotId();
 
       if (snapshotResult?.snapshotBase64) {
@@ -361,35 +487,37 @@ export class ExecutorService implements ExecutorRequestHandler {
         emitter.emit('event', snapshotEvent);
       }
 
-      const doneEvent: TaskDoneEvent = {
+      // Emit round_done (NOT done — session stays alive)
+      const roundDoneEvent: TaskRoundDoneEvent = {
         delegationId,
-        type: 'done',
+        type: 'round_done',
         timestamp: new Date().toISOString(),
+        round,
         summary: result.summary,
         highlights: result.highlights,
         snapshotIds: snapshotResult?.snapshotBase64 ? [snapshotId] : undefined,
         recommendedSnapshotId: snapshotResult?.snapshotBase64 ? snapshotId : undefined,
       };
+      emitter.emit('event', roundDoneEvent);
 
-      emitter.emit('event', doneEvent);
-      console.log(
-        `[AWCP:Executor] Task ${delegationId} done event emitted` +
-        ` (listeners=${emitter.listenerCount('event')})`
-      );
-      this.config.hooks.onTaskComplete?.(delegationId, result.summary);
+      this.transitionState(delegationId, { type: 'ROUND_COMPLETE' });
 
-      this.transitionState(delegationId, { type: 'TASK_COMPLETE' });
-      assignment.completedAt = new Date().toISOString();
-      assignment.result = {
-        summary: result.summary,
-        highlights: result.highlights,
-        snapshotBase64: snapshotResult?.snapshotBase64,
-      };
+      // Update round record
+      const currentRoundRecord = assignment.rounds[assignment.rounds.length - 1];
+      if (currentRoundRecord) {
+        currentRoundRecord.completedAt = new Date().toISOString();
+        currentRoundRecord.result = { summary: result.summary, highlights: result.highlights };
+      }
+
+      assignment.result = { summary: result.summary, highlights: result.highlights };
       await this.persistAssignment(delegationId);
 
-      await this.transport.detach({ delegationId, localPath: assignment.workPath }).catch(() => {});
+      // Do NOT detach transport — workspace stays alive for next round
+      console.log(`[AWCP:Executor] Round ${round} completed for ${delegationId} (state=idle)`);
+      this.config.hooks.onTaskComplete?.(delegationId, result.summary);
+
     } catch (error) {
-      console.error(`[AWCP:Executor] Task ${delegationId} failed:`, error instanceof Error ? error.message : error);
+      console.error(`[AWCP:Executor] Round ${round} failed for ${delegationId}:`, error instanceof Error ? error.message : error);
 
       const errorEvent: TaskErrorEvent = {
         delegationId,
@@ -399,16 +527,7 @@ export class ExecutorService implements ExecutorRequestHandler {
         message: error instanceof Error ? error.message : String(error),
         hint: 'Check task requirements and try again',
       };
-
       emitter.emit('event', errorEvent);
-      console.log(
-        `[AWCP:Executor] Task ${delegationId} error event emitted` +
-        ` (listeners=${emitter.listenerCount('event')})`
-      );
-      this.config.hooks.onError?.(
-        delegationId,
-        error instanceof Error ? error : new Error(String(error))
-      );
 
       this.transitionState(delegationId, { type: 'TASK_FAIL' });
       assignment.completedAt = new Date().toISOString();
@@ -418,8 +537,8 @@ export class ExecutorService implements ExecutorRequestHandler {
         hint: 'Check task requirements and try again',
       };
       await this.persistAssignment(delegationId);
-
       await this.transport.detach({ delegationId, localPath: assignment.workPath }).catch(() => {});
+      this.config.hooks.onError?.(delegationId, error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -458,7 +577,7 @@ export class ExecutorService implements ExecutorRequestHandler {
   }
 
   getStatus(): ExecutorServiceStatus {
-    const active = Array.from(this.assignments.values()).filter(a => a.state === 'active');
+    const active = Array.from(this.assignments.values()).filter(a => a.state === 'active' || a.state === 'idle');
     return {
       pendingInvitations: Array.from(this.assignments.values()).filter(a => a.state === 'pending').length,
       activeDelegations: active.length,

--- a/packages/sdk/src/executor/service.ts
+++ b/packages/sdk/src/executor/service.ts
@@ -148,11 +148,6 @@ export class ExecutorService implements ExecutorRequestHandler {
       existing.state = 'pending';
       existing.invite = invite;
       existing.retentionMs = retentionMs;
-      existing.lease = undefined;
-      existing.startedAt = undefined;
-      existing.completedAt = undefined;
-      existing.result = undefined;
-      existing.error = undefined;
 
       this.stateMachines.set(delegationId, new AssignmentStateMachine());
       this.eventEmitters.set(delegationId, new EventEmitter());

--- a/packages/sdk/src/executor/service.ts
+++ b/packages/sdk/src/executor/service.ts
@@ -148,6 +148,11 @@ export class ExecutorService implements ExecutorRequestHandler {
       existing.state = 'pending';
       existing.invite = invite;
       existing.retentionMs = retentionMs;
+      existing.lease = undefined;
+      existing.startedAt = undefined;
+      existing.completedAt = undefined;
+      existing.result = undefined;
+      existing.error = undefined;
 
       this.stateMachines.set(delegationId, new AssignmentStateMachine());
       this.eventEmitters.set(delegationId, new EventEmitter());

--- a/packages/sdk/src/listener/http-listener.ts
+++ b/packages/sdk/src/listener/http-listener.ts
@@ -65,6 +65,7 @@ export class HttpListener implements ListenerAdapter {
           clearInterval(heartbeat);
           res.end();
         }
+        // round_done keeps the SSE connection alive
       });
 
       req.on('close', () => {

--- a/packages/transport-archive/test/archive-transport.test.ts
+++ b/packages/transport-archive/test/archive-transport.test.ts
@@ -189,3 +189,127 @@ describe('ArchiveExecutorTransport', () => {
     expect(zips).toHaveLength(0);
   });
 });
+
+describe('Multi-round support', () => {
+  let tempDir: string;
+  let delegator: ArchiveDelegatorTransport;
+  let executor: ArchiveExecutorTransport;
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'awcp-test-'));
+    delegator = new ArchiveDelegatorTransport({ tempDir });
+    executor = new ArchiveExecutorTransport({ tempDir });
+    await delegator.initialize();
+    await executor.initialize();
+  });
+
+  afterEach(async () => {
+    await delegator.shutdown();
+    await executor.shutdown();
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should preserve workspace across detach for multi-round use', async () => {
+    const exportDir = path.join(tempDir, 'export');
+    await fs.promises.mkdir(exportDir, { recursive: true });
+    await fs.promises.writeFile(path.join(exportDir, 'file.txt'), 'initial');
+
+    const handle = await delegator.prepare({
+      delegationId: 'multi-round',
+      exportPath: exportDir,
+      ttlSeconds: 300,
+    });
+
+    const localPath = path.join(tempDir, 'work');
+    await executor.setup({ delegationId: 'multi-round', handle, localPath });
+
+    await fs.promises.writeFile(path.join(localPath, 'file.txt'), 'round 1');
+    const round1 = await executor.captureSnapshot({ delegationId: 'multi-round', localPath });
+    expect(round1.snapshotBase64).toBeDefined();
+
+    await delegator.detach('multi-round');
+    await executor.detach({ delegationId: 'multi-round', localPath });
+
+    const stat = await fs.promises.stat(localPath);
+    expect(stat.isDirectory()).toBe(true);
+    const contentAfterDetach = await fs.promises.readFile(path.join(localPath, 'file.txt'), 'utf-8');
+    expect(contentAfterDetach).toBe('round 1');
+
+    await fs.promises.writeFile(path.join(localPath, 'file.txt'), 'round 2');
+    await fs.promises.writeFile(path.join(localPath, 'new.txt'), 'added in round 2');
+
+    const round2 = await executor.captureSnapshot({ delegationId: 'multi-round', localPath });
+    expect(round2.snapshotBase64).toBeDefined();
+
+    const resultZip = path.join(tempDir, 'round2-verify.zip');
+    await fs.promises.writeFile(resultZip, Buffer.from(round2.snapshotBase64, 'base64'));
+    const resultDir = path.join(tempDir, 'round2-verify');
+    await extractArchive(resultZip, resultDir);
+
+    expect(await fs.promises.readFile(path.join(resultDir, 'file.txt'), 'utf-8')).toBe('round 2');
+    expect(await fs.promises.readFile(path.join(resultDir, 'new.txt'), 'utf-8')).toBe('added in round 2');
+  });
+
+  it('should allow multiple snapshots across rounds with different content', async () => {
+    const exportDir = path.join(tempDir, 'export');
+    await fs.promises.mkdir(exportDir, { recursive: true });
+    await fs.promises.writeFile(path.join(exportDir, 'data.txt'), 'seed');
+
+    const handle = await delegator.prepare({
+      delegationId: 'snapshot-diff',
+      exportPath: exportDir,
+      ttlSeconds: 300,
+    });
+
+    const localPath = path.join(tempDir, 'work');
+    await executor.setup({ delegationId: 'snapshot-diff', handle, localPath });
+
+    await fs.promises.writeFile(path.join(localPath, 'data.txt'), 'round 1 content');
+    const round1 = await executor.captureSnapshot({ delegationId: 'snapshot-diff', localPath });
+
+    const round1Zip = path.join(tempDir, 'r1.zip');
+    await fs.promises.writeFile(round1Zip, Buffer.from(round1.snapshotBase64, 'base64'));
+    const round1Dir = path.join(tempDir, 'r1');
+    await extractArchive(round1Zip, round1Dir);
+    expect(await fs.promises.readFile(path.join(round1Dir, 'data.txt'), 'utf-8')).toBe('round 1 content');
+
+    await delegator.detach('snapshot-diff');
+    await executor.detach({ delegationId: 'snapshot-diff', localPath });
+
+    await fs.promises.writeFile(path.join(localPath, 'data.txt'), 'round 2 content');
+    const round2 = await executor.captureSnapshot({ delegationId: 'snapshot-diff', localPath });
+
+    const round2Zip = path.join(tempDir, 'r2.zip');
+    await fs.promises.writeFile(round2Zip, Buffer.from(round2.snapshotBase64, 'base64'));
+    const round2Dir = path.join(tempDir, 'r2');
+    await extractArchive(round2Zip, round2Dir);
+    expect(await fs.promises.readFile(path.join(round2Dir, 'data.txt'), 'utf-8')).toBe('round 2 content');
+
+    expect(round1.snapshotBase64).not.toBe(round2.snapshotBase64);
+  });
+
+  it('should clean up only on release, not detach', async () => {
+    const exportDir = path.join(tempDir, 'export');
+    await fs.promises.mkdir(exportDir, { recursive: true });
+    await fs.promises.writeFile(path.join(exportDir, 'keep.txt'), 'persist');
+
+    const handle = await delegator.prepare({
+      delegationId: 'cleanup-test',
+      exportPath: exportDir,
+      ttlSeconds: 300,
+    });
+
+    const localPath = path.join(tempDir, 'work');
+    await executor.setup({ delegationId: 'cleanup-test', handle, localPath });
+
+    await delegator.detach('cleanup-test');
+    await executor.detach({ delegationId: 'cleanup-test', localPath });
+
+    const existsAfterDetach = await fs.promises.stat(localPath).then(() => true, () => false);
+    expect(existsAfterDetach).toBe(true);
+    expect(await fs.promises.readFile(path.join(localPath, 'keep.txt'), 'utf-8')).toBe('persist');
+
+    await delegator.release('cleanup-test');
+    await executor.release({ delegationId: 'cleanup-test', localPath });
+  });
+});

--- a/packages/transport-git/src/executor/transport.ts
+++ b/packages/transport-git/src/executor/transport.ts
@@ -117,8 +117,9 @@ export class GitExecutorTransport implements ExecutorTransportAdapter {
   }
 
   async detach(params: TransportReleaseParams): Promise<void> {
+    // Clean up auth tokens but keep activeSetups for multi-round sessions.
+    // Only release() deletes the setup entry (final cleanup).
     await cleanupAuth(params.localPath).catch(() => {});
-    this.activeSetups.delete(params.delegationId);
   }
 
   async release(params: TransportReleaseParams): Promise<void> {

--- a/packages/transport-git/test/git-transport.test.ts
+++ b/packages/transport-git/test/git-transport.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { GitDelegatorTransport } from '../src/delegator/transport.js';
 import { GitExecutorTransport } from '../src/executor/transport.js';
 import { join } from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 
 describe('GitDelegatorTransport', () => {
   describe('constructor', () => {
@@ -137,5 +138,153 @@ describe('GitExecutorTransport', () => {
         transport.release({ delegationId: 'nonexistent', localPath: '/tmp/nonexistent' }),
       ).resolves.toBeUndefined();
     });
+  });
+});
+
+describe('Multi-round integration', () => {
+  let tempDir: string;
+  let bareRepoPath: string;
+  let delegator: GitDelegatorTransport;
+  let executor: GitExecutorTransport;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'awcp-git-mr-'));
+    bareRepoPath = join(tempDir, 'remote.git');
+
+    execFileSync('git', ['init', '--bare', '--initial-branch=main', bareRepoPath]);
+
+    delegator = new GitDelegatorTransport({
+      remoteUrl: bareRepoPath,
+      auth: { type: 'none' },
+      tempDir: join(tempDir, 'delegator-tmp'),
+    });
+
+    executor = new GitExecutorTransport({
+      tempDir: join(tempDir, 'executor-tmp'),
+    });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function createSourceWorkspace(content: string): Promise<string> {
+    const srcDir = join(tempDir, 'source-workspace');
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(join(srcDir, 'file.txt'), content);
+
+    execFileSync('git', ['init', '--initial-branch=main'], { cwd: srcDir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: srcDir });
+    execFileSync('git', ['config', 'user.email', 'test@test.local'], { cwd: srcDir });
+    execFileSync('git', ['add', '-A'], { cwd: srcDir });
+    execFileSync('git', ['commit', '-m', 'initial'], { cwd: srcDir });
+
+    return srcDir;
+  }
+
+  async function prepareAndSetup(delegationId: string, initialContent: string) {
+    const srcDir = await createSourceWorkspace(initialContent);
+    const handle = await delegator.prepare({
+      delegationId,
+      exportPath: srcDir,
+      ttlSeconds: 3600,
+    });
+
+    const localPath = join(tempDir, 'executor-work', delegationId);
+    await mkdir(localPath, { recursive: true });
+
+    await executor.setup({ delegationId, handle, localPath });
+    return localPath;
+  }
+
+  it('should preserve activeSetups across detach for multi-round snapshots', async () => {
+    const delegationId = 'mr-preserve';
+    const localPath = await prepareAndSetup(delegationId, 'initial');
+
+    await writeFile(join(localPath, 'file.txt'), 'round1');
+    const round1 = await executor.captureSnapshot({ delegationId, localPath });
+    const snap1 = JSON.parse(round1.snapshotBase64);
+    expect(snap1.branch).toBeTruthy();
+    expect(snap1.commitHash).toBeTruthy();
+
+    await executor.detach({ delegationId, localPath });
+
+    await writeFile(join(localPath, 'file.txt'), 'round2');
+    const round2 = await executor.captureSnapshot({ delegationId, localPath });
+    const snap2 = JSON.parse(round2.snapshotBase64);
+    expect(snap2.branch).toBe(snap1.branch);
+    expect(snap2.commitHash).toBeTruthy();
+    expect(snap2.commitHash).not.toBe(snap1.commitHash);
+  });
+
+  it('should allow delegator to apply snapshots from different rounds', async () => {
+    const delegationId = 'mr-apply';
+    const localPath = await prepareAndSetup(delegationId, 'initial');
+
+    await writeFile(join(localPath, 'file.txt'), 'round1');
+    await executor.captureSnapshot({ delegationId, localPath });
+    await executor.detach({ delegationId, localPath });
+
+    await writeFile(join(localPath, 'file.txt'), 'round2-content');
+    const round2 = await executor.captureSnapshot({ delegationId, localPath });
+    const snap2 = JSON.parse(round2.snapshotBase64);
+
+    await delegator.applySnapshot({
+      delegationId,
+      snapshotData: round2.snapshotBase64,
+      resources: [],
+    });
+
+    const delegatorWorkDir = join(tempDir, 'delegator-tmp', delegationId);
+    const content = await readFile(join(delegatorWorkDir, 'file.txt'), 'utf-8');
+    expect(content).toBe('round2-content');
+  });
+
+  it('should fail captureSnapshot after release but succeed after detach', async () => {
+    const delegationId = 'mr-release';
+    const localPath = await prepareAndSetup(delegationId, 'initial');
+
+    await writeFile(join(localPath, 'file.txt'), 'snap1');
+    await executor.captureSnapshot({ delegationId, localPath });
+
+    await executor.detach({ delegationId, localPath });
+
+    await writeFile(join(localPath, 'file.txt'), 'snap2');
+    await executor.captureSnapshot({ delegationId, localPath });
+
+    await executor.release({ delegationId, localPath });
+
+    await writeFile(join(localPath, 'file.txt'), 'snap3');
+    await expect(
+      executor.captureSnapshot({ delegationId, localPath }),
+    ).rejects.toThrow(`no active setup for delegation ${delegationId}`);
+  });
+
+  it('should support full lifecycle: setup → round1 → detach → round2 → detach → release', async () => {
+    const delegationId = 'mr-full';
+    const localPath = await prepareAndSetup(delegationId, 'initial');
+
+    await writeFile(join(localPath, 'file.txt'), 'v1');
+    const round1 = await executor.captureSnapshot({ delegationId, localPath });
+    const snap1 = JSON.parse(round1.snapshotBase64);
+    expect(snap1.commitHash).toBeTruthy();
+
+    await executor.detach({ delegationId, localPath });
+
+    await writeFile(join(localPath, 'file.txt'), 'v2');
+    const round2 = await executor.captureSnapshot({ delegationId, localPath });
+    const snap2 = JSON.parse(round2.snapshotBase64);
+    expect(snap2.commitHash).toBeTruthy();
+    expect(snap2.commitHash).not.toBe(snap1.commitHash);
+    expect(snap2.branch).toBe(snap1.branch);
+
+    await executor.detach({ delegationId, localPath });
+
+    await delegator.release(delegationId);
+    await executor.release({ delegationId, localPath });
+
+    await expect(
+      executor.captureSnapshot({ delegationId, localPath }),
+    ).rejects.toThrow(`no active setup for delegation ${delegationId}`);
   });
 });

--- a/packages/transport-sshfs/src/delegator/transport.ts
+++ b/packages/transport-sshfs/src/delegator/transport.ts
@@ -52,8 +52,9 @@ export class SshfsDelegatorTransport implements DelegatorTransportAdapter {
     return handle;
   }
 
-  async detach(delegationId: string): Promise<void> {
-    await this.credentialManager.revokeCredential(delegationId);
+  async detach(_delegationId: string): Promise<void> {
+    // No-op: credentials stay alive between rounds for multi-round sessions.
+    // Only release() revokes credentials (final cleanup).
   }
 
   async release(delegationId: string): Promise<void> {

--- a/packages/transport-sshfs/src/executor/transport.ts
+++ b/packages/transport-sshfs/src/executor/transport.ts
@@ -59,8 +59,9 @@ export class SshfsExecutorTransport implements ExecutorTransportAdapter {
     return localPath;
   }
 
-  async detach(params: TransportReleaseParams): Promise<void> {
-    await this.mountClient.unmount(params.localPath);
+  async detach(_params: TransportReleaseParams): Promise<void> {
+    // No-op: mount stays alive between rounds for multi-round sessions.
+    // Only release() unmounts (final cleanup).
   }
 
   async release(params: TransportReleaseParams): Promise<void> {

--- a/packages/transport-sshfs/test/multi-round.test.ts
+++ b/packages/transport-sshfs/test/multi-round.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Multi-Round Integration Tests
+ *
+ * Tests that detach() is a no-op (state preserved between rounds) while
+ * release() performs final cleanup for both delegator and executor transports.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdir, rm, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+import { SshfsDelegatorTransport } from '../src/delegator/transport.js';
+import { SshfsExecutorTransport } from '../src/executor/transport.js';
+
+describe('Multi-round: SshfsDelegatorTransport', () => {
+  let testDir: string;
+  let keyDir: string;
+  let caKeyPath: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `awcp-multi-round-delegator-${Date.now()}`);
+    keyDir = join(testDir, 'keys');
+    caKeyPath = join(testDir, 'ca');
+
+    await mkdir(keyDir, { recursive: true });
+
+    execSync(`ssh-keygen -t ed25519 -f "${caKeyPath}" -N "" -C "test-ca"`, {
+      stdio: 'ignore',
+    });
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('detach should not revoke credentials', async () => {
+    const transport = new SshfsDelegatorTransport({
+      caKeyPath,
+      keyDir,
+      host: 'localhost',
+      port: 22,
+      user: 'testuser',
+    });
+
+    const delegationId = `detach-test-${Date.now()}`;
+    await transport.prepare({
+      delegationId,
+      exportPath: '/export/workspace',
+      ttlSeconds: 3600,
+    });
+
+    const privateKeyPath = join(keyDir, delegationId);
+    const publicKeyPath = join(keyDir, `${delegationId}.pub`);
+    const certPath = join(keyDir, `${delegationId}-cert.pub`);
+
+    await expect(access(privateKeyPath)).resolves.not.toThrow();
+    await expect(access(certPath)).resolves.not.toThrow();
+
+    await transport.detach(delegationId);
+
+    await expect(access(privateKeyPath)).resolves.not.toThrow();
+    await expect(access(publicKeyPath)).resolves.not.toThrow();
+    await expect(access(certPath)).resolves.not.toThrow();
+  });
+
+  it('release should revoke credentials', async () => {
+    const transport = new SshfsDelegatorTransport({
+      caKeyPath,
+      keyDir,
+      host: 'localhost',
+      port: 22,
+      user: 'testuser',
+    });
+
+    const delegationId = `release-test-${Date.now()}`;
+    await transport.prepare({
+      delegationId,
+      exportPath: '/export/workspace',
+      ttlSeconds: 3600,
+    });
+
+    const privateKeyPath = join(keyDir, delegationId);
+    const publicKeyPath = join(keyDir, `${delegationId}.pub`);
+    const certPath = join(keyDir, `${delegationId}-cert.pub`);
+
+    await expect(access(privateKeyPath)).resolves.not.toThrow();
+
+    await transport.release(delegationId);
+
+    await expect(access(privateKeyPath)).rejects.toThrow();
+    await expect(access(publicKeyPath)).rejects.toThrow();
+    await expect(access(certPath)).rejects.toThrow();
+  });
+
+  it('credentials survive detach but are cleaned up by release', async () => {
+    const transport = new SshfsDelegatorTransport({
+      caKeyPath,
+      keyDir,
+      host: 'localhost',
+      port: 22,
+      user: 'testuser',
+    });
+
+    const delegationId = `full-cycle-${Date.now()}`;
+    await transport.prepare({
+      delegationId,
+      exportPath: '/export/workspace',
+      ttlSeconds: 3600,
+    });
+
+    const privateKeyPath = join(keyDir, delegationId);
+    const certPath = join(keyDir, `${delegationId}-cert.pub`);
+
+    await transport.detach(delegationId);
+    await transport.detach(delegationId);
+    await transport.detach(delegationId);
+
+    await expect(access(privateKeyPath)).resolves.not.toThrow();
+    await expect(access(certPath)).resolves.not.toThrow();
+
+    await transport.release(delegationId);
+
+    await expect(access(privateKeyPath)).rejects.toThrow();
+    await expect(access(certPath)).rejects.toThrow();
+  });
+});
+
+describe('Multi-round: SshfsExecutorTransport', () => {
+  let testDir: string;
+  let transport: SshfsExecutorTransport;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `awcp-multi-round-executor-${Date.now()}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  beforeEach(() => {
+    transport = new SshfsExecutorTransport({ tempKeyDir: testDir });
+  });
+
+  it('detach should be a no-op (not unmount)', async () => {
+    const mountClient = (transport as any).mountClient;
+    const mounts = mountClient.getActiveMounts();
+
+    mounts.set('/mnt/round-test', {
+      mountPoint: '/mnt/round-test',
+      keyPath: join(testDir, 'key1'),
+      certPath: join(testDir, 'key1-cert.pub'),
+    });
+
+    expect(mounts.size).toBe(1);
+
+    await transport.detach({ delegationId: 'test-1', localPath: '/mnt/round-test' });
+
+    expect(mounts.size).toBe(1);
+    expect(mounts.has('/mnt/round-test')).toBe(true);
+  });
+
+  it('release should remove mount tracking entry', async () => {
+    const mountClient = (transport as any).mountClient;
+    const mounts = mountClient.getActiveMounts();
+
+    mounts.set('/mnt/release-test', {
+      mountPoint: '/mnt/release-test',
+      keyPath: join(testDir, 'key2'),
+      certPath: join(testDir, 'key2-cert.pub'),
+    });
+
+    expect(mounts.has('/mnt/release-test')).toBe(true);
+
+    await transport.release({ delegationId: 'test-2', localPath: '/mnt/release-test' });
+
+    expect(mounts.has('/mnt/release-test')).toBe(false);
+  });
+
+  it('mount tracking survives multiple detach calls', async () => {
+    const mountClient = (transport as any).mountClient;
+    const mounts = mountClient.getActiveMounts();
+
+    mounts.set('/mnt/multi-detach', {
+      mountPoint: '/mnt/multi-detach',
+      keyPath: join(testDir, 'key3'),
+      certPath: join(testDir, 'key3-cert.pub'),
+    });
+
+    await transport.detach({ delegationId: 'test-3', localPath: '/mnt/multi-detach' });
+    await transport.detach({ delegationId: 'test-3', localPath: '/mnt/multi-detach' });
+    await transport.detach({ delegationId: 'test-3', localPath: '/mnt/multi-detach' });
+
+    expect(mounts.size).toBe(1);
+    expect(mounts.get('/mnt/multi-detach')?.mountPoint).toBe('/mnt/multi-detach');
+  });
+});

--- a/packages/transport-storage/src/executor/transport.ts
+++ b/packages/transport-storage/src/executor/transport.ts
@@ -107,8 +107,9 @@ export class StorageExecutorTransport implements ExecutorTransportAdapter {
     }
   }
 
-  async detach(params: TransportReleaseParams): Promise<void> {
-    this.activeHandles.delete(params.delegationId);
+  async detach(_params: TransportReleaseParams): Promise<void> {
+    // No-op: handle stays alive between rounds for multi-round sessions.
+    // Only release() clears the handle (final cleanup).
   }
 
   async release(params: TransportReleaseParams): Promise<void> {

--- a/packages/transport-storage/test/storage-transport.test.ts
+++ b/packages/transport-storage/test/storage-transport.test.ts
@@ -273,7 +273,7 @@ describe('StorageExecutorTransport', () => {
     expect(await fs.promises.readFile(path.join(resultDir, 'new-file.txt'), 'utf-8')).toBe('new file content');
   });
 
-  it('should clean stored handle on detach', async () => {
+  it('should preserve stored handle after detach (multi-round support)', async () => {
     const exportDir = path.join(tempDir, 'export');
     await fs.promises.mkdir(exportDir, { recursive: true });
     await fs.promises.writeFile(path.join(exportDir, 'test.txt'), 'hello');
@@ -293,8 +293,159 @@ describe('StorageExecutorTransport', () => {
       localPath,
     });
 
+    const snapshotInfo = JSON.parse(result.snapshotBase64);
+    expect(snapshotInfo.resultUrl).toContain('http://localhost');
+  });
+
+  it('should clean stored handle on release (final cleanup)', async () => {
+    const exportDir = path.join(tempDir, 'export');
+    await fs.promises.mkdir(exportDir, { recursive: true });
+    await fs.promises.writeFile(path.join(exportDir, 'test.txt'), 'hello');
+
+    const handle = await delegator.prepare({
+      delegationId: 'test-delegation',
+      exportPath: exportDir,
+      ttlSeconds: 300,
+    });
+
+    const localPath = path.join(tempDir, 'work');
+    await executor.setup({ delegationId: 'test-delegation', handle, localPath });
+    await executor.release({ delegationId: 'test-delegation', localPath });
+
+    const result = await executor.captureSnapshot({
+      delegationId: 'test-delegation',
+      localPath,
+    });
+
     const snapshotData = result.snapshotBase64;
     expect(() => JSON.parse(snapshotData)).toThrow();
+  });
+
+  describe('Multi-round scenarios', () => {
+    it('should support multiple snapshot captures across rounds without re-setup', async () => {
+      const exportDir = path.join(tempDir, 'export');
+      await fs.promises.mkdir(exportDir, { recursive: true });
+      await fs.promises.writeFile(path.join(exportDir, 'data.txt'), 'initial');
+
+      const handle = await delegator.prepare({
+        delegationId: 'test-delegation',
+        exportPath: exportDir,
+        ttlSeconds: 300,
+      });
+
+      const localPath = path.join(tempDir, 'work');
+      await executor.setup({ delegationId: 'test-delegation', handle, localPath });
+
+      await fs.promises.writeFile(path.join(localPath, 'data.txt'), 'round 1');
+      const result1 = await executor.captureSnapshot({
+        delegationId: 'test-delegation',
+        localPath,
+      });
+      const snapshot1 = JSON.parse(result1.snapshotBase64);
+      expect(snapshot1.resultUrl).toContain('http://localhost');
+
+      await executor.detach({ delegationId: 'test-delegation', localPath });
+
+      await fs.promises.writeFile(path.join(localPath, 'data.txt'), 'round 2');
+      const result2 = await executor.captureSnapshot({
+        delegationId: 'test-delegation',
+        localPath,
+      });
+      const snapshot2 = JSON.parse(result2.snapshotBase64);
+      expect(snapshot2.resultUrl).toContain('http://localhost');
+    });
+
+    it('should upload to correct URL across multiple rounds', async () => {
+      const exportDir = path.join(tempDir, 'export');
+      await fs.promises.mkdir(exportDir, { recursive: true });
+      await fs.promises.writeFile(path.join(exportDir, 'file.txt'), 'original');
+
+      const handle = await delegator.prepare({
+        delegationId: 'test-delegation',
+        exportPath: exportDir,
+        ttlSeconds: 300,
+      });
+
+      const localPath = path.join(tempDir, 'work');
+      await executor.setup({ delegationId: 'test-delegation', handle, localPath });
+
+      await fs.promises.writeFile(path.join(localPath, 'file.txt'), 'round 1 content');
+      const result1 = await executor.captureSnapshot({
+        delegationId: 'test-delegation',
+        localPath,
+      });
+      const snapshot1 = JSON.parse(result1.snapshotBase64);
+
+      const response1 = await fetch(snapshot1.resultUrl);
+      expect(response1.ok).toBe(true);
+      const buffer1 = Buffer.from(await response1.arrayBuffer());
+      const verifyZip1 = path.join(tempDir, 'verify-round1.zip');
+      await fs.promises.writeFile(verifyZip1, buffer1);
+      const verifyDir1 = path.join(tempDir, 'verify-round1');
+      await extractArchive(verifyZip1, verifyDir1);
+      expect(await fs.promises.readFile(path.join(verifyDir1, 'file.txt'), 'utf-8')).toBe('round 1 content');
+
+      await executor.detach({ delegationId: 'test-delegation', localPath });
+
+      await fs.promises.writeFile(path.join(localPath, 'file.txt'), 'round 2 content');
+      const result2 = await executor.captureSnapshot({
+        delegationId: 'test-delegation',
+        localPath,
+      });
+      const snapshot2 = JSON.parse(result2.snapshotBase64);
+
+      const response2 = await fetch(snapshot2.resultUrl);
+      expect(response2.ok).toBe(true);
+      const buffer2 = Buffer.from(await response2.arrayBuffer());
+      const verifyZip2 = path.join(tempDir, 'verify-round2.zip');
+      await fs.promises.writeFile(verifyZip2, buffer2);
+      const verifyDir2 = path.join(tempDir, 'verify-round2');
+      await extractArchive(verifyZip2, verifyDir2);
+      expect(await fs.promises.readFile(path.join(verifyDir2, 'file.txt'), 'utf-8')).toBe('round 2 content');
+    });
+
+    it('should support full multi-round lifecycle: setup → round1 → detach → round2 → detach → release', async () => {
+      const exportDir = path.join(tempDir, 'export');
+      await fs.promises.mkdir(exportDir, { recursive: true });
+      await fs.promises.writeFile(path.join(exportDir, 'version.txt'), 'v1');
+
+      const handle = await delegator.prepare({
+        delegationId: 'test-delegation',
+        exportPath: exportDir,
+        ttlSeconds: 300,
+      });
+
+      const localPath = path.join(tempDir, 'work');
+      await executor.setup({ delegationId: 'test-delegation', handle, localPath });
+
+      await fs.promises.writeFile(path.join(localPath, 'version.txt'), 'v2');
+      const result1 = await executor.captureSnapshot({
+        delegationId: 'test-delegation',
+        localPath,
+      });
+      const snapshot1 = JSON.parse(result1.snapshotBase64);
+      expect(snapshot1.resultUrl).toContain('http://localhost');
+
+      await executor.detach({ delegationId: 'test-delegation', localPath });
+
+      await fs.promises.writeFile(path.join(localPath, 'version.txt'), 'v3');
+      const result2 = await executor.captureSnapshot({
+        delegationId: 'test-delegation',
+        localPath,
+      });
+      const snapshot2 = JSON.parse(result2.snapshotBase64);
+      expect(snapshot2.resultUrl).toContain('http://localhost');
+
+      await executor.detach({ delegationId: 'test-delegation', localPath });
+
+      await executor.release({ delegationId: 'test-delegation', localPath });
+
+      const result3 = await executor.captureSnapshot({
+        delegationId: 'test-delegation',
+        localPath,
+      });
+      expect(() => JSON.parse(result3.snapshotBase64)).toThrow();
+    });
   });
 });
 


### PR DESCRIPTION
# AWCP 多轮委派状态更新说明（Delegator ⇄ Executor）

本次PR记录当前 AWCP 为支持多轮委派（multi-round delegation）而新增/修改的状态层更新，以及相关测试覆盖情况。

## 1. 变更目标与核心语义

多轮委派的核心语义是：

- **同一个 delegation 会话 = 1 份数据层生命周期 + N 轮任务**
- 每轮完成后进入 **idle**，等待继续或关闭
- **detach** 只做“轮间暂停”，**release** 才是“最终销毁”

因此，所有 layer 的改动都围绕两点：

1. 新增 **idle/round** 概念与事件
2. **detach / release** 语义彻底区分

## 2. Core 协议层更新（@awcp/core）

### 2.1 新增消息类型与事件
- `MessageType` 新增：`CONTINUE` / `CLOSE`
- Task SSE 事件新增：`round_done`
- `ContinueMessage` 包含 `task` + `round` + `lease?`
- `CloseMessage` 作为多轮会话终结信号

### 2.2 Delegation / Assignment 状态扩展
- `DelegationState` 新增：`idle`
- `AssignmentState` 新增：`idle`
- Delegation/Assignment 记录新增：
  - `currentRound: number`
  - `rounds: Round[]`
- `Round` 结构包含：`number`, `task`, `result`, `snapshots`, `startedAt`, `completedAt`

### 2.3 状态机更新
**DelegationStateMachine：**
- `running → idle`（ROUND_COMPLETE）
- `idle → running`（SEND_CONTINUE）
- `idle → completed`（SEND_CLOSE）
- `idle` 也支持 `error/cancelled/expired`

**AssignmentStateMachine：**
- `active → idle`（ROUND_COMPLETE）
- `idle → active`（RECEIVE_CONTINUE）
- `idle → completed`（RECEIVE_CLOSE）

> 单轮模式保持兼容：`running → completed` 仍然允许

## 3. SDK 层更新（@awcp/sdk）

### 3.1 DelegatorService
新增与调整：
- `continue()`：发送 CONTINUE，推进 round，并从 `idle → running`
- `close()`：发送 CLOSE，结束会话（`idle → completed`）
- `handleRoundDone()`：处理 `round_done` SSE 事件，将状态 `running → idle`
- **SSE 连接不在 round_done 时关闭，仅在 done/error 时关闭**
- `activeStreams` 记录每个 delegation 的 SSE stream
- 最终清理：**close() 改为调用 transport.release()**（不是 detach）

### 3.2 ExecutorService
新增与调整：
- `handleContinue()`：接收 CONTINUE，进入新一轮执行（不重新 setup）
- `_doRound()`：执行任务后发送 `round_done`，转入 idle
- `handleClose()`：发送 `done` 并终止会话
- 最终清理：**handleClose() 改为 transport.release()**

### 3.3 DelegatorDaemonClient
新增：
- `waitForIdle()`：等待 round 完成（idle 或 terminal）
- `continueDelegation()` / `closeDelegation()` API

## 4. MCP 层更新（@awcp/mcp）

新增工具：
- `delegate_continue`：对 idle delegation 发起新一轮
- `delegate_close`：结束多轮会话

输出改进：
- `delegate_output` 支持展示 idle 状态
- 输出增加 `round history` 与 `current round` 信息
- idle 状态提示下一步动作（continue / close）

## 5. Transport 层语义调整

### 5.1 detach / release 语义统一
- **detach：轮间暂停，不销毁任何状态**
- **release：最终清理，释放资源**

### 5.2 具体 transport 调整

| Transport | 变更点 | 原行为 | 新行为 |
|-----------|-------|--------|--------|
| sshfs (delegator) | detach | revokeCredential | no-op |
| sshfs (executor) | detach | unmount | no-op |
| storage (executor) | detach | activeHandles.delete | no-op |
| git (executor) | detach | activeSetups.delete | 仅 cleanup auth |
| archive | detach | no-op | 不变 |

最终清理统一由 `release()` 执行。

## 6. 兼容性说明

- 单轮流程完全兼容：`running → completed` 仍然有效
- 不使用 `CONTINUE` / `CLOSE` 的客户端不会受影响
- 旧 transport detach 行为已修正，确保多轮环境一致

---

# Tests（详细说明）

本次新增/修改测试共 17 个，覆盖四种 transport 的多轮行为，并补充了 detach/release 的语义差异。

## 1. Archive Transport（新增 3 个测试）
文件：`packages/transport-archive/test/archive-transport.test.ts`

**新增 describe: `Multi-round support`**

1. **should preserve workspace across detach for multi-round use**
   - setup → round1 修改 → snapshot
   - detach
   - 验证工作区仍存在且内容保留
   - round2 修改 → snapshot → 解压验证 round2 内容

2. **should allow multiple snapshots across rounds with different content**
   - round1/round2 生成两个 snapshot
   - 解压验证内容不同
   - snapshotBase64 不同

3. **should clean up only on release, not detach**
   - detach 后目录仍存在
   - release 才执行最终清理

## 2. SSHFS Transport（新增 6 个测试）
文件：`packages/transport-sshfs/test/multi-round.test.ts`

### Delegator 侧（3 个）
1. **detach should not revoke credentials**
   - prepare 生成 key/cert
   - detach 后文件仍在

2. **release should revoke credentials**
   - release 后 key/cert 文件删除

3. **credentials survive detach but are cleaned up by release**
   - 多次 detach 仍保留
   - release 后清理

### Executor 侧（3 个）
4. **detach should be a no-op (not unmount)**
   - 手工写入 activeMounts
   - detach 后 entry 仍存在

5. **release should remove mount tracking entry**
   - release 后 entry 移除

6. **mount tracking survives multiple detach calls**
   - 多次 detach entry 不变

> 由于 CI 无 sshfs 挂载能力，测试只验证状态与 tracking 逻辑

## 3. Storage Transport（新增 3 个测试 + 修改 1 个旧测试）
文件：`packages/transport-storage/test/storage-transport.test.ts`

**修改旧测试：**
- 原本验证 “detach 会清理 handle” 的测试已改为：
  - `detach` 后仍能 captureSnapshot
  - `release` 才清理 handle

**新增 describe: `Multi-round scenarios`**

1. **should support multiple snapshot captures across rounds without re-setup**
   - setup 一次
   - round1 snapshot → detach
   - round2 snapshot → 验证 resultUrl 仍可用

2. **should upload to correct URL across multiple rounds**
   - round1 snapshot 下载解压验证内容
   - detach → round2 snapshot 下载解压验证内容更新

3. **should support full multi-round lifecycle**
   - setup → round1 → detach → round2 → detach → release
   - release 后 captureSnapshot fallback（无法 JSON.parse）

## 4. Git Transport（新增 4 个测试）
文件：`packages/transport-git/test/git-transport.test.ts`

**新增 describe: `Multi-round integration`**
- 使用本地 bare repo 作为 remote，执行真实 git 操作

1. **should preserve activeSetups across detach for multi-round snapshots**
   - round1/round2 连续 snapshot
   - branch 相同，commitHash 不同

2. **should allow delegator to apply snapshots from different rounds**
   - executor 生成 round2 snapshot
   - delegator applySnapshot 后验证工作区内容

3. **should fail captureSnapshot after release but succeed after detach**
   - detach 后仍可 snapshot
   - release 后 snapshot 抛错

4. **should support full lifecycle**
   - setup → round1 → detach → round2 → detach → release
   - release 后 snapshot 抛错

---

# 本地多轮委派验证示例（最小可复现）

> 该示例已在本地验证可用，适合快速确认 multi-round 是否正常。

## 1) 启动 Delegator Daemon（终端 A，常驻）

```bash
mkdir -p /tmp/awcp/environments /tmp/awcp/temp

node --input-type=module -e '
import { startDelegatorDaemon } from "@awcp/sdk/delegator/daemon";
import { ArchiveDelegatorTransport } from "@awcp/transport-archive";

const daemon = await startDelegatorDaemon({
  port: 3100,
  delegator: {
    baseDir: "/tmp/awcp/environments",
    transport: new ArchiveDelegatorTransport({ tempDir: "/tmp/awcp/temp" }),
  },
});

console.log("[AWCP] Delegator daemon ready at", daemon.url);
process.on("SIGINT", async () => { await daemon.shutdown(); process.exit(0); });
await new Promise(() => {});
'
```

> 注意：Delegator 和 Executor 都需要独立进程常驻运行。

## 2) 启动 Executor（终端 B，常驻）

```bash
cd /Users/dp/Agent_research/projects/awcp/examples/local-executor
SII_API_KEY=sk-xxx node executor.js --port 10200
```

## 3) Round 1 发起委派（终端 C）

```bash
curl --noproxy localhost,127.0.0.1 -s http://localhost:3100/delegate \
  -H "Content-Type: application/json" \
  -d '{
    "executorUrl": "http://localhost:10200/awcp",
    "environment": {
      "resources": [{
        "name": "workspace",
        "type": "fs",
        "source": "/Users/dp/Agent_research/projects/workspace",
        "mode": "rw"
      }]
    },
    "task": {
      "description": "Round 1",
      "prompt": "请在workspace根目录创建文件 round1.txt 并写入 round1"
    },
    "snapshotMode": "auto",
    "ttlSeconds": 3600
  }'
```

返回 `delegationId` 之后，等待进入 `idle`：

```bash
curl --noproxy localhost,127.0.0.1 -s \
  http://localhost:3100/delegation/<delegationId> | jq '.state'
```

## 4) Round 2 继续执行

```bash
curl --noproxy localhost,127.0.0.1 -X POST \
  http://localhost:3100/delegation/<delegationId>/continue \
  -H "Content-Type: application/json" \
  -d '{
    "task": {
      "description": "Round 2",
      "prompt": "请创建 round2.txt 内容为 round2"
    }
  }'
```

再次查询状态，直到 `idle`：

```bash
curl --noproxy localhost,127.0.0.1 -s \
  http://localhost:3100/delegation/<delegationId> | jq '.state'
```

## 5) 关闭会话（最终清理）

```bash
curl --noproxy localhost,127.0.0.1 -X POST \
  http://localhost:3100/delegation/<delegationId>/close
```

### 预期状态流
```
Round1: running → idle
Round2: running → idle
Close : completed
```
